### PR TITLE
Task 7 (Authorization)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ node_modules
 # CDK asset staging directory
 .cdk.staging
 cdk.out
+
+.env

--- a/cdk.ts
+++ b/cdk.ts
@@ -4,6 +4,7 @@ import { AwsHosting } from './lib/awsHosting';
 
 import { ProductsService } from './services/product-service';
 import { ImportService } from './services/import-service';
+import { AuthService } from './services/authorization-service';
 
 class AwsHostingStack extends cdk.Stack { // stack it is cloud formation
   constructor(parent: cdk.App, name: string) {
@@ -29,11 +30,20 @@ class ImportStack extends cdk.Stack {
   }
 }
 
+class AuthStack extends cdk.Stack {
+  constructor(parent: cdk.App, name: string) {
+    super(parent, name);
+
+    new AuthService(this, 'Auth');
+  }
+}
+
 const app = new cdk.App();
 
 new AwsHostingStack(app, 'TsimanovichAWSRS');
 new ProductStack(app, 'TsimanovichAWSRSProduct');
 new ImportStack(app, 'TsimanovichAWSRSImport');
+new AuthStack(app, 'TsimanovichAWSRSAuth');
 
 app.synth();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@aws-cdk/aws-lambda-nodejs": "^1.204.0",
         "@aws-sdk/lib-dynamodb": "^3.454.0",
         "csv-parse": "^5.5.2",
+        "dotenv": "^16.3.1",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -8208,6 +8209,17 @@
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/easy-table": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@aws-cdk/aws-lambda-nodejs": "^1.204.0",
     "@aws-sdk/lib-dynamodb": "^3.454.0",
     "csv-parse": "^5.5.2",
+    "dotenv": "^16.3.1",
     "uuid": "^9.0.1"
   }
 }

--- a/services/authorization-service/index.ts
+++ b/services/authorization-service/index.ts
@@ -1,0 +1,21 @@
+import { Construct } from '@aws-cdk/core';
+import * as lambda from '@aws-cdk/aws-lambda';
+import { NodejsFunction } from '@aws-cdk/aws-lambda-nodejs';
+import * as path from 'path';
+import 'dotenv/config';
+
+export class AuthService extends Construct {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const basicAuthorizerHandler = new NodejsFunction(this, 'basicAuthorizerHandler', {
+      memorySize: 1024,
+      runtime: lambda.Runtime.NODEJS_16_X,
+      entry: path.join(__dirname, `./lambdas/basicAuthorizer/index.ts`),
+      handler: 'handler',
+      environment: {
+        NastyaTsimanovich97: process.env.NastyaTsimanovich97!,
+      }
+    });
+  }
+}

--- a/services/authorization-service/lambdas/basicAuthorizer/index.ts
+++ b/services/authorization-service/lambdas/basicAuthorizer/index.ts
@@ -1,0 +1,20 @@
+import { buildAuthResponse } from '../../utils/buildAuthResponse';
+
+export const handler = async function(event: any) {
+  console.log(`event:`, event);
+
+  const token = event.authorizationToken?.split(' ').pop();
+
+  if (!token || token === 'null' || token === 'undefined') {
+    throw new Error('Unauthorized');
+  }
+
+  const buf = Buffer.from(token, 'base64');
+  const [userName, pass] = buf.toString('utf-8').split(':');
+
+  const envPassword = process.env?.[userName];
+
+  const isAuth = pass === envPassword;
+
+  return buildAuthResponse(isAuth ? 'Allow' : 'Deny', event.methodArn);
+}

--- a/services/authorization-service/utils/buildAuthResponse.ts
+++ b/services/authorization-service/utils/buildAuthResponse.ts
@@ -1,0 +1,15 @@
+export function buildAuthResponse(Effect: 'Allow' | 'Deny', Resource: string) {
+  return {
+    principalId: 'user',
+    policyDocument: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Action: 'execute-api:Invoke',
+          Effect,
+          Resource,
+        },
+      ],
+    },
+  };
+}

--- a/services/product-service/index.ts
+++ b/services/product-service/index.ts
@@ -116,7 +116,7 @@ export class ProductsService extends Construct {
       restApiName: 'products',
       description: 'This service return products.',
       defaultCorsPreflightOptions: {
-        allowHeaders: ['Content-Type'],
+        allowHeaders: ['Content-Type', 'Authorization'],
         allowMethods: apigateway.Cors.ALL_METHODS,
         allowOrigins: apigateway.Cors.ALL_ORIGINS,
       },


### PR DESCRIPTION
### **Task 7.1**
- [x] Create a new service called `authorization-service` at the same level as Product and Import services with its own AWS CDK Stack.
- [x] Create a lambda function called `basicAuthorizer` under the Authorization Service.
- [x] Credentials `{yours_github_account_login}=TEST_PASSWORD`.
- [x] This basicAuthorizer lambda should take Basic Authorization token, decode it and check that credentials provided by token exist in the lambda environment variable.
- [x] This lambda should return 403 HTTP status if access is denied for this user (invalid authorization_token) and 401 HTTP status if Authorization header is not provided. 

Example of products file --> [products.csv](https://github.com/NastyaTsimanovich97/aws-rs-be/files/13627848/products.csv)


### **Task 7.2**
- [x] Add Lambda authorization to the `/import` path of the Import Service API Gateway.
- [x] Use your `basicAuthorizer` lambda as the Lambda authorizer.


### **Task 7.3**
- [x] Request from the client application to the /import path of the Import Service should have Basic Authorization header.
- [x] Client should get authorization_token value from browser [localStorage](https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage).

### **Additional scope**
--

### **Link to FE**
[Products page](https://d2ka0e4af31lyd.cloudfront.net/)

### **Link to FE PR**
[FE PR](https://github.com/NastyaTsimanovich97/aws-rs-fe/pull/4)
